### PR TITLE
Fix profile strings

### DIFF
--- a/CloudFrontMiddleware/RSAUtils.swift
+++ b/CloudFrontMiddleware/RSAUtils.swift
@@ -38,7 +38,10 @@ func dataFromPEM(_ pem: String, startTag: String, endTag: String) -> Data? {
     else {
         return nil
     }
-    let keyDataBase64 = String(pem[startIndex ..< endIndex]).components(separatedBy: .newlines).joined()
+    let keyDataBase64 = String(pem[startIndex ..< endIndex])
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+        .components(separatedBy: .newlines)
+        .joined()
     guard let keyData = Data(base64Encoded: keyDataBase64) else {
         return nil
     }

--- a/CloudFrontMiddleware/RSAUtils.swift
+++ b/CloudFrontMiddleware/RSAUtils.swift
@@ -38,7 +38,7 @@ func dataFromPEM(_ pem: String, startTag: String, endTag: String) -> Data? {
     else {
         return nil
     }
-    let keyDataBase64 = String(pem[startIndex ..< endIndex]).split(separator: "\n").joined()
+    let keyDataBase64 = String(pem[startIndex ..< endIndex]).components(separatedBy: .newlines).joined()
     guard let keyData = Data(base64Encoded: keyDataBase64) else {
         return nil
     }


### PR DESCRIPTION
This fixes an issue where pem strings are base64encoded, such as profiles. The `String(data: pem, encoding: .utf8)` conversion within `rsaPrivateKeyFromPemData` was not re-encoding properly.

Debugging efforts showed that the string was being decoded properly and the RSA Private Key was being printed as expected, but was failing to re-encode.

This fix improves robustness of the temporary array that is generated. It now trims all whitespace characters and splits on all newline characters instead of just `\n`.